### PR TITLE
Fixed licensing and cleanup on test project

### DIFF
--- a/CDPBatchEditor.Tests/AppTestFixture.cs
+++ b/CDPBatchEditor.Tests/AppTestFixture.cs
@@ -1,31 +1,30 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="AppTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="AppTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests
 {
-    using CDPBatchEditor.CommandArguments.Interface;
     using CDPBatchEditor.Commands.Interface;
     using CDPBatchEditor.Services.Interfaces;
 
@@ -36,10 +35,6 @@ namespace CDPBatchEditor.Tests
     [TestFixture]
     public class AppTestFixture
     {
-        private App app;
-        private Mock<ICommandDispatcher> commandDispatcher;
-        private Mock<ISessionService> sessionService;
-
         [SetUp]
         public void Setup()
         {
@@ -47,6 +42,10 @@ namespace CDPBatchEditor.Tests
             this.sessionService = new Mock<ISessionService>();
             this.app = new App(this.sessionService.Object, this.commandDispatcher.Object);
         }
+
+        private App app;
+        private Mock<ICommandDispatcher> commandDispatcher;
+        private Mock<ISessionService> sessionService;
 
         [Test]
         public void VerifyRun()

--- a/CDPBatchEditor.Tests/CommandArgumentsTestFixture.cs
+++ b/CDPBatchEditor.Tests/CommandArgumentsTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CommandArgumentsTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CommandArgumentsTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests
 {
@@ -37,10 +37,6 @@ namespace CDPBatchEditor.Tests
     [TestFixture]
     public class CommandArgumentsTestFixture
     {
-        private const string StringArguments = " -s http://test.com -u admin -p pass  --action AddParameters --parameter-group groupname -m TEST --parameters parameter1,parameter2 --element-definition elementdefinition --domain testDomain";
-        private Arguments commandArguments;
-        private IEnumerable<Error> errors;
-
         [SetUp]
         public void Setup()
         {
@@ -50,6 +46,10 @@ namespace CDPBatchEditor.Tests
                     e => this.errors = e)
                 .WithParsed(commandArgument => this.commandArguments = commandArgument);
         }
+
+        private const string StringArguments = " -s http://test.com -u admin -p pass  --action AddParameters --parameter-group groupname -m TEST --parameters parameter1,parameter2 --element-definition elementdefinition --domain testDomain";
+        private Arguments commandArguments;
+        private IEnumerable<Error> errors;
 
         [Test]
         public void VerifyToString()

--- a/CDPBatchEditor.Tests/Commands/Command/BaseCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/BaseCommandTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="BaseCommandTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="BaseCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {
@@ -51,6 +51,25 @@ namespace CDPBatchEditor.Tests.Commands.Command
     {
         private const string BaseUri = "http://test.com";
         private readonly string baseArguments = $" -s {BaseUri} -u admin -p pass ";
+        private ElementDefinition elementDefinition2;
+        private ElementDefinition elementDefinition3;
+        private ElementDefinition elementDefinition4;
+        private EngineeringModelSetup engineeringModelSetup;
+        private EngineeringModel model;
+        private ModelReferenceDataLibrary modelReferenceDataLibrary;
+        private TextParameterType parameterType;
+        private TextParameterType parameterType2;
+        private SimpleQuantityKind parameterType3;
+        private SimpleQuantityKind parameterType4;
+        private SimpleQuantityKind parameterType5;
+        private SimpleQuantityKind parameterType6;
+        private SimpleQuantityKind parameterType7;
+        private Participant participant;
+        private Person person;
+        private SiteDirectory siteDirectory;
+        private SiteReferenceDataLibrary siteReferenceDataLibrary;
+
+        private Uri uri;
 
         internal ICommandArguments CommandArguments { get; private set; }
 
@@ -79,6 +98,7 @@ namespace CDPBatchEditor.Tests.Commands.Command
         public Parameter Parameter2 { get; private set; }
 
         public Parameter Parameter3 { get; private set; }
+
         public Parameter Parameter3s { get; private set; }
 
         public Parameter Parameter4 { get; private set; }
@@ -104,29 +124,12 @@ namespace CDPBatchEditor.Tests.Commands.Command
         public Assembler Assembler { get; set; }
 
         public ParameterSubscription ParameterSubscription { get; set; }
+
         public ParameterSubscription ParameterSubscription1 { get; set; }
+
         public ParameterSubscription ParameterSubscription2 { get; set; }
 
         public ElementDefinition TestElementDefinition { get; set; }
-
-        private Uri uri;
-        private SiteDirectory siteDirectory;
-        private TextParameterType parameterType;
-        private TextParameterType parameterType2;
-        private SimpleQuantityKind parameterType3;
-        private EngineeringModel model;
-        private EngineeringModelSetup engineeringModelSetup;
-        private SiteReferenceDataLibrary siteReferenceDataLibrary;
-        private ModelReferenceDataLibrary modelReferenceDataLibrary;
-        private Person person;
-        private Participant participant;
-        private ElementDefinition elementDefinition3;
-        private ElementDefinition elementDefinition2;
-        private SimpleQuantityKind parameterType4;
-        private ElementDefinition elementDefinition4;
-        private SimpleQuantityKind parameterType7;
-        private SimpleQuantityKind parameterType5;
-        private SimpleQuantityKind parameterType6;
 
         [SetUp]
         public void Setup()
@@ -405,7 +408,7 @@ namespace CDPBatchEditor.Tests.Commands.Command
 
             var parameterOverride = new ParameterOverride(Guid.NewGuid(), this.Assembler.Cache, this.uri) { Owner = this.Domain, Parameter = this.Parameter };
 
-            var elementUsage = new ElementUsage(Guid.NewGuid(), this.Assembler.Cache, this.uri) { ElementDefinition = this.TestElementDefinition, Owner = this.Domain};
+            var elementUsage = new ElementUsage(Guid.NewGuid(), this.Assembler.Cache, this.uri) { ElementDefinition = this.TestElementDefinition, Owner = this.Domain };
             elementUsage.ParameterOverride.Add(parameterOverride);
             this.TestElementDefinition.ContainedElement.Add(elementUsage);
         }

--- a/CDPBatchEditor.Tests/Commands/Command/DomainCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/DomainCommandTestFixture.cs
@@ -1,34 +1,35 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="DoaminCommandTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="DomainCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {
     using System.Linq;
-    
+
     using CDP4Common.EngineeringModelData;
     using CDP4Common.SiteDirectoryData;
+
     using CDPBatchEditor.Commands.Command;
 
     using NUnit.Framework;
@@ -42,36 +43,6 @@ namespace CDPBatchEditor.Tests.Commands.Command
         {
             base.BuildAction(action);
             this.domainCommand = new DomainCommand(this.CommandArguments, this.SessionService.Object, this.FilterService.Object);
-        }
-
-        [Test]
-        public void VerifySetGenericEquipmentOwnership()
-        {
-            var action = "--action SetGenericOwners -m TEST --element-definition testElementDefinition4 --domain testDomain";
-            this.BuildAction(action);
-
-            var oldOwner1 = this.Parameter5.Owner;
-            var oldOwner2 = this.Parameter6.Owner;
-            var oldOwner3 = this.Parameter7.Owner;
-
-            Assert.AreSame(this.Domain, oldOwner1);
-            Assert.AreSame(this.Domain, oldOwner2);
-            Assert.AreSame(this.Domain, oldOwner3);
-
-            this.domainCommand.SetGenericEquipmentOwnership();
-
-            Assert.AreEqual(3, this.Transactions.Count);
-
-            Assert.IsNotEmpty(this.Transactions.SelectMany(x => x.UpdatedThing));
-            Assert.IsEmpty(this.Transactions.SelectMany(x => x.AddedThing));
-
-            var updateParameters = this.Transactions.SelectMany(x => x.UpdatedThing).Where(u => u.Value is Parameter p).Select(u => u.Value as Parameter).ToList();
-            var parameter = updateParameters.FirstOrDefault(x => x.ParameterType.ShortName == this.Parameter5.ParameterType.ShortName);
-            this.AssertThingHasExpectedOwner(oldOwner1, this.Domain3, parameter);
-            parameter = updateParameters.FirstOrDefault(x => x.ParameterType.ShortName == this.Parameter6.ParameterType.ShortName);
-            this.AssertThingHasExpectedOwner(oldOwner2, this.Domain4, parameter);
-            parameter = updateParameters.FirstOrDefault(x => x.ParameterType.ShortName == this.Parameter7.ParameterType.ShortName);
-            this.AssertThingHasExpectedOwner(oldOwner3, this.Domain5, parameter);
         }
 
         private void AssertThingHasExpectedOwner(DomainOfExpertise oldOwner, DomainOfExpertise newOwner, IOwnedThing thing)
@@ -99,7 +70,7 @@ namespace CDPBatchEditor.Tests.Commands.Command
 
             Assert.IsTrue(this.Transactions.All(x => x.UpdatedThing.Any() && x.UpdatedThing.All(y => y.Value is IOwnedThing p && p.Owner == this.Domain2)));
 
-            var updatedParameters = this.Transactions.SelectMany(x => x.UpdatedThing.Values.Select(t => t as Parameter).Where(e => e != null ));
+            var updatedParameters = this.Transactions.SelectMany(x => x.UpdatedThing.Values.Select(t => t as Parameter).Where(e => e != null));
             var updatedElementDefinitions = this.Transactions.SelectMany(x => x.UpdatedThing.Values.Select(t => t as ElementDefinition).Where(e => e != null));
 
             foreach (var thing in this.Transactions.SelectMany(x => x.UpdatedThing.Values.Select(t => t as IOwnedThing)))
@@ -150,6 +121,36 @@ namespace CDPBatchEditor.Tests.Commands.Command
             {
                 this.AssertThingHasExpectedOwner(this.Domain, this.Domain2, thing);
             }
+        }
+
+        [Test]
+        public void VerifySetGenericEquipmentOwnership()
+        {
+            var action = "--action SetGenericOwners -m TEST --element-definition testElementDefinition4 --domain testDomain";
+            this.BuildAction(action);
+
+            var oldOwner1 = this.Parameter5.Owner;
+            var oldOwner2 = this.Parameter6.Owner;
+            var oldOwner3 = this.Parameter7.Owner;
+
+            Assert.AreSame(this.Domain, oldOwner1);
+            Assert.AreSame(this.Domain, oldOwner2);
+            Assert.AreSame(this.Domain, oldOwner3);
+
+            this.domainCommand.SetGenericEquipmentOwnership();
+
+            Assert.AreEqual(3, this.Transactions.Count);
+
+            Assert.IsNotEmpty(this.Transactions.SelectMany(x => x.UpdatedThing));
+            Assert.IsEmpty(this.Transactions.SelectMany(x => x.AddedThing));
+
+            var updateParameters = this.Transactions.SelectMany(x => x.UpdatedThing).Where(u => u.Value is Parameter p).Select(u => u.Value as Parameter).ToList();
+            var parameter = updateParameters.FirstOrDefault(x => x.ParameterType.ShortName == this.Parameter5.ParameterType.ShortName);
+            this.AssertThingHasExpectedOwner(oldOwner1, this.Domain3, parameter);
+            parameter = updateParameters.FirstOrDefault(x => x.ParameterType.ShortName == this.Parameter6.ParameterType.ShortName);
+            this.AssertThingHasExpectedOwner(oldOwner2, this.Domain4, parameter);
+            parameter = updateParameters.FirstOrDefault(x => x.ParameterType.ShortName == this.Parameter7.ParameterType.ShortName);
+            this.AssertThingHasExpectedOwner(oldOwner3, this.Domain5, parameter);
         }
     }
 }

--- a/CDPBatchEditor.Tests/Commands/Command/OptionCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/OptionCommandTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="OptionCommandTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="OptionCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {

--- a/CDPBatchEditor.Tests/Commands/Command/ParameterCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/ParameterCommandTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ParameterCommandTestfixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ParameterCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {

--- a/CDPBatchEditor.Tests/Commands/Command/ScaleCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/ScaleCommandTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ScaleCommandTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ScaleCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {
@@ -85,9 +85,9 @@ namespace CDPBatchEditor.Tests.Commands.Command
             Assert.IsTrue(
                 this.Transactions.Any(
                     t => t.UpdatedThing.Any(
-                        a => a.Value is Parameter p
-                             && p.Scale == this.MillimeterScale
-                             && p.ParameterType.ShortName == parameterShortName) || t.UpdatedThing.Any(
+                             a => a.Value is Parameter p
+                                  && p.Scale == this.MillimeterScale
+                                  && p.ParameterType.ShortName == parameterShortName) || t.UpdatedThing.Any(
                              a => a.Value is ParameterSubscription p
                                   && p.Scale == this.MillimeterScale
                                   && p.ParameterType.ShortName == parameterShortName)));

--- a/CDPBatchEditor.Tests/Commands/Command/StateCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/StateCommandTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="StateCommandTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="StateCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {

--- a/CDPBatchEditor.Tests/Commands/Command/SubscriptionCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/SubscriptionCommandTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="SubscriptionCommandTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="SubscriptionCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {
@@ -46,26 +46,6 @@ namespace CDPBatchEditor.Tests.Commands.Command
         }
 
         [Test]
-        public void VerifySubscribeToParameters()
-        {
-            const string parameterUserFriendlyShortName = "testParameter2", elementDefinitionShortName = "testElementDefinition", domain = "testDomain2";
-            this.BuildAction($"--action={CommandEnumeration.Subscribe} -m TEST --parameters={parameterUserFriendlyShortName} --element-definition={elementDefinitionShortName} --domain={domain}");
-
-            Assert.IsFalse(this.Parameter2.ParameterSubscription.Any());
-
-            this.subscriptionCommand.Subscribe();
-
-            Assert.AreEqual(1, this.Transactions.First().UpdatedThing.Count);
-            Assert.AreEqual(1, this.Transactions.First().AddedThing.Count());
-
-            Assert.IsTrue(this.Transactions.Any(t => t.AddedThing.Any(p => p is ParameterSubscription s && s.Owner == this.Domain2)));
-
-            Assert.IsTrue(this.Transactions.Any(t => t.UpdatedThing.Any(u => u.Value is Parameter p
-                                                                             && p.ParameterSubscription.Any(s => s.Owner.ShortName == domain)
-                                                                             && p.ParameterType.ShortName == parameterUserFriendlyShortName)));
-        }
-
-        [Test]
         public void VerifySetParameterSubscriptionsSwitch()
         {
             const string parameterUserFriendlyShortName = "testParameter3", elementDefinitionShortName = "testElementDefinition";
@@ -87,6 +67,26 @@ namespace CDPBatchEditor.Tests.Commands.Command
 
             Assert.IsNotNull(valueSet);
             Assert.AreEqual(ParameterSwitchKind.REFERENCE, valueSet.ValueSwitch);
+        }
+
+        [Test]
+        public void VerifySubscribeToParameters()
+        {
+            const string parameterUserFriendlyShortName = "testParameter2", elementDefinitionShortName = "testElementDefinition", domain = "testDomain2";
+            this.BuildAction($"--action={CommandEnumeration.Subscribe} -m TEST --parameters={parameterUserFriendlyShortName} --element-definition={elementDefinitionShortName} --domain={domain}");
+
+            Assert.IsFalse(this.Parameter2.ParameterSubscription.Any());
+
+            this.subscriptionCommand.Subscribe();
+
+            Assert.AreEqual(1, this.Transactions.First().UpdatedThing.Count);
+            Assert.AreEqual(1, this.Transactions.First().AddedThing.Count());
+
+            Assert.IsTrue(this.Transactions.Any(t => t.AddedThing.Any(p => p is ParameterSubscription s && s.Owner == this.Domain2)));
+
+            Assert.IsTrue(this.Transactions.Any(t => t.UpdatedThing.Any(u => u.Value is Parameter p
+                                                                             && p.ParameterSubscription.Any(s => s.Owner.ShortName == domain)
+                                                                             && p.ParameterType.ShortName == parameterUserFriendlyShortName)));
         }
     }
 }

--- a/CDPBatchEditor.Tests/Commands/Command/ValueSetCommandTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/Command/ValueSetCommandTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ValueSetCommandTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ValueSetCommandTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands.Command
 {

--- a/CDPBatchEditor.Tests/Commands/CommandDispatcherTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/CommandDispatcherTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="CommandDispatcherTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CommandDispatcherTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands
 {
@@ -41,17 +41,6 @@ namespace CDPBatchEditor.Tests.Commands
     [TestFixture]
     public class CommandDispatcherTestFixture
     {
-        private Mock<ICommandArguments> commandArguments;
-        private Mock<IParameterCommand> parameterCommand;
-        private Mock<ISubscriptionCommand> subscriptionCommand;
-        private Mock<IOptionCommand> optionCommand;
-        private Mock<IScaleCommand> scaleCommand;
-        private Mock<IStateCommand> stateCommand;
-        private Mock<IDomainCommand> domainCommand;
-        private Mock<IValueSetCommand> valueSetCommand;
-        private Mock<IReportGenerator> reportGenerator;
-        private CommandDispatcher commandDispatcher;
-
         [SetUp]
         public void Setup()
         {
@@ -71,6 +60,17 @@ namespace CDPBatchEditor.Tests.Commands
                 this.commandArguments.Object, this.parameterCommand.Object, this.subscriptionCommand.Object, this.optionCommand.Object,
                 this.scaleCommand.Object, this.stateCommand.Object, this.domainCommand.Object, this.valueSetCommand.Object, this.reportGenerator.Object);
         }
+
+        private Mock<ICommandArguments> commandArguments;
+        private Mock<IParameterCommand> parameterCommand;
+        private Mock<ISubscriptionCommand> subscriptionCommand;
+        private Mock<IOptionCommand> optionCommand;
+        private Mock<IScaleCommand> scaleCommand;
+        private Mock<IStateCommand> stateCommand;
+        private Mock<IDomainCommand> domainCommand;
+        private Mock<IValueSetCommand> valueSetCommand;
+        private Mock<IReportGenerator> reportGenerator;
+        private CommandDispatcher commandDispatcher;
 
         [Test]
         public void VerifyInvoke()

--- a/CDPBatchEditor.Tests/Commands/ReportGeneratorTestFixture.cs
+++ b/CDPBatchEditor.Tests/Commands/ReportGeneratorTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ReportGeneratorTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ReportGeneratorTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Commands
 {
@@ -45,6 +45,12 @@ namespace CDPBatchEditor.Tests.Commands
     [TestFixture]
     public class ReportGeneratorTestFixture
     {
+        [SetUp]
+        public void Setup()
+        {
+            this.SetupData();
+        }
+
         private const string BaseUri = "http://test.com";
 
         internal Iteration Iteration { get; private set; }
@@ -94,18 +100,6 @@ namespace CDPBatchEditor.Tests.Commands
         private SimpleQuantityKind parameterType4;
         private Mock<ISessionService> sessionService;
         private ReportGenerator reportGenerator;
-
-        [SetUp]
-        public void Setup()
-        {
-            this.SetupData();
-        }
-
-        [Test]
-        public void VerifyParameterToCsv()
-        {
-            this.reportGenerator.ParametersToCsv();
-        }
 
         private void SetupData()
         {
@@ -344,6 +338,12 @@ namespace CDPBatchEditor.Tests.Commands
             this.siteReferenceDataLibrary.ParameterType.Add(this.parameterType2);
             this.siteReferenceDataLibrary.ParameterType.Add(this.parameterType3);
             this.siteReferenceDataLibrary.ParameterType.Add(this.parameterType4);
+        }
+
+        [Test]
+        public void VerifyParameterToCsv()
+        {
+            this.reportGenerator.ParametersToCsv();
         }
     }
 }

--- a/CDPBatchEditor.Tests/ProgramTestFixture.cs
+++ b/CDPBatchEditor.Tests/ProgramTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ProgramTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ProgramTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests
 {
@@ -41,12 +41,6 @@ namespace CDPBatchEditor.Tests
     [TestFixture]
     public class ProgramTestFixture
     {
-        private const string SampleArguments = "-s http://localhost:5000 -u admin -p pass --action ChangeDomain -m LOFT --parameters m,l,h --element-definition a1mil_layer_kapton_on_BEE_boxes --domain THE --to-domain SYS";
-        private const string WrongSampleArguments = "-w http://localhost:5000 -u admin -p pass --action ChangeDomain -m LOFT --parameters m,l,h --element-definition a1mil_layer_kapton_on_BEE_boxes --domain THE --to-domain SYS";
-        private Mock<IApp> app;
-        private Mock<IResourceLoader> resourceLoader;
-        private Mock<ICommandArguments> commandArguments;
-
         [SetUp]
         public void Setup()
         {
@@ -62,23 +56,26 @@ namespace CDPBatchEditor.Tests
             AppContainer.Container = containerBuilder.Build();
         }
 
-        [Test]
-        public void VerifyMain()
-        {
-            var arguments = WrongSampleArguments.Split(' ');
-            Program.Main(arguments);
-            this.VerifyCalls(Times.Never());
-
-            arguments = SampleArguments.Split(' ');
-            Program.Main(arguments);
-            this.VerifyCalls(Times.Once());
-        }
+        private const string SampleArguments = "-s http://localhost:5000 -u admin -p pass --action ChangeDomain -m LOFT --parameters m,l,h --element-definition a1mil_layer_kapton_on_BEE_boxes --domain THE --to-domain SYS";
+        private const string WrongSampleArguments = "-w http://localhost:5000 -u admin -p pass --action ChangeDomain -m LOFT --parameters m,l,h --element-definition a1mil_layer_kapton_on_BEE_boxes --domain THE --to-domain SYS";
+        private Mock<IApp> app;
+        private Mock<IResourceLoader> resourceLoader;
+        private Mock<ICommandArguments> commandArguments;
 
         private void VerifyCalls(Times times)
         {
             this.resourceLoader.Verify(x => x.LoadEmbeddedResource(It.IsAny<string>()), times);
             this.app.Verify(x => x.Run(), times);
             this.app.Verify(x => x.Stop(), times);
+        }
+
+        [Test]
+        public void VerifyAssemblyVersion()
+        {
+            var version = Program.QueryBatchEditorVersion();
+            Assert.IsNotNull(version);
+            Assert.AreEqual(4, version.Split('.').Length);
+            Assert.IsNotNull(new Version(version));
         }
 
         [Test]
@@ -94,12 +91,15 @@ namespace CDPBatchEditor.Tests
         }
 
         [Test]
-        public void VerifyAssemblyVersion()
+        public void VerifyMain()
         {
-            var version = Program.QueryBatchEditorVersion();
-            Assert.IsNotNull(version);
-            Assert.AreEqual(4, version.Split('.').Length);
-            Assert.IsNotNull(new Version(version));
+            var arguments = WrongSampleArguments.Split(' ');
+            Program.Main(arguments);
+            this.VerifyCalls(Times.Never());
+
+            arguments = SampleArguments.Split(' ');
+            Program.Main(arguments);
+            this.VerifyCalls(Times.Once());
         }
     }
 }

--- a/CDPBatchEditor.Tests/Resources/ResourcesTestFixture.cs
+++ b/CDPBatchEditor.Tests/Resources/ResourcesTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="ResourcesTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="ResourcesTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Resources
 {
@@ -35,15 +35,15 @@ namespace CDPBatchEditor.Tests.Resources
     [TestFixture]
     public class ResourcesTestFixture
     {
-        private string path;
-        private ResourceLoader resourceLoader;
-
         [SetUp]
         public void Setup()
         {
             this.path = "CDPBatchEditor.Resources.ascii-art.txt";
             this.resourceLoader = new ResourceLoader();
         }
+
+        private string path;
+        private ResourceLoader resourceLoader;
 
         [Test]
         public void LoadEmbeddedResource()

--- a/CDPBatchEditor.Tests/Services/FilterServiceTestFixture.cs
+++ b/CDPBatchEditor.Tests/Services/FilterServiceTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="FilterServiceTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="FilterServiceTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Services
 {
@@ -43,21 +43,6 @@ namespace CDPBatchEditor.Tests.Services
     [TestFixture]
     public class FilterServiceTestFixture
     {
-        private const string BaseUri = "http://test.com";
-        private Mock<ICommandArguments> commandArguments;
-        private FilterService filterService;
-        private Uri uri;
-        private Assembler assembler;
-        private SiteDirectory siteDirectory;
-        private Iteration iteration;
-        private DomainOfExpertise domain;
-        private ElementDefinition elementDefinition;
-        private ElementDefinition elementDefinition2;
-        private DomainOfExpertise domain3;
-        private DomainOfExpertise domain2;
-        private Parameter parameter2;
-        private Parameter parameter;
-
         [SetUp]
         public void Setup()
         {
@@ -80,7 +65,7 @@ namespace CDPBatchEditor.Tests.Services
             this.elementDefinition = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "e", Owner = this.domain };
             this.elementDefinition2 = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "e2", Owner = this.domain };
 
-            this.elementDefinition.ContainedElement.Add(new ElementUsage(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "e2u", Owner = this.domain, ElementDefinition = this.elementDefinition2});
+            this.elementDefinition.ContainedElement.Add(new ElementUsage(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "e2u", Owner = this.domain, ElementDefinition = this.elementDefinition2 });
             var parameterType = new DateTimeParameterType(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "t" };
             var parameterType2 = new SimpleQuantityKind(Guid.NewGuid(), this.assembler.Cache, this.uri) { ShortName = "o" };
             this.parameter = new Parameter(Guid.NewGuid(), this.assembler.Cache, this.uri) { ParameterType = parameterType };
@@ -113,18 +98,20 @@ namespace CDPBatchEditor.Tests.Services
             this.filterService = new FilterService(this.commandArguments.Object);
         }
 
-        [Test]
-        public void VerifyIsParameterSpecifiedOrAny()
-        {
-            Assert.IsFalse(this.filterService.IsParameterSpecifiedOrAny(new Parameter() { ParameterType = new BooleanParameterType() { ShortName = "returnFalse" } }));
-
-            Assert.IsTrue(this.filterService.IsParameterSpecifiedOrAny(this.parameter));
-
-            this.commandArguments.Setup(x => x.SelectedParameters).Returns(new List<string>());
-
-            Assert.IsEmpty(this.commandArguments.Object.SelectedParameters);
-            Assert.IsTrue(this.filterService.IsParameterSpecifiedOrAny(this.parameter));
-        }
+        private const string BaseUri = "http://test.com";
+        private Mock<ICommandArguments> commandArguments;
+        private FilterService filterService;
+        private Uri uri;
+        private Assembler assembler;
+        private SiteDirectory siteDirectory;
+        private Iteration iteration;
+        private DomainOfExpertise domain;
+        private ElementDefinition elementDefinition;
+        private ElementDefinition elementDefinition2;
+        private DomainOfExpertise domain3;
+        private DomainOfExpertise domain2;
+        private Parameter parameter2;
+        private Parameter parameter;
 
         [Test]
         public void VerifyIsFilteredInOrFilterIsEmpty()
@@ -136,6 +123,19 @@ namespace CDPBatchEditor.Tests.Services
             Assert.IsFalse(this.filterService.IsFilteredInOrFilterIsEmpty(dummyElement));
             this.filterService.FilteredElementDefinitions.Clear();
             Assert.IsTrue(this.filterService.IsFilteredInOrFilterIsEmpty(dummyElement));
+        }
+
+        [Test]
+        public void VerifyIsParameterSpecifiedOrAny()
+        {
+            Assert.IsFalse(this.filterService.IsParameterSpecifiedOrAny(new Parameter() { ParameterType = new BooleanParameterType() { ShortName = "returnFalse" } }));
+
+            Assert.IsTrue(this.filterService.IsParameterSpecifiedOrAny(this.parameter));
+
+            this.commandArguments.Setup(x => x.SelectedParameters).Returns(new List<string>());
+
+            Assert.IsEmpty(this.commandArguments.Object.SelectedParameters);
+            Assert.IsTrue(this.filterService.IsParameterSpecifiedOrAny(this.parameter));
         }
 
         [Test]

--- a/CDPBatchEditor.Tests/Services/SessionServiceTestFixture.cs
+++ b/CDPBatchEditor.Tests/Services/SessionServiceTestFixture.cs
@@ -1,27 +1,27 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="SessionServiceTestFixture.cs" company="RHEA System S.A.">
-//    Copyright (c) 2015-2020 RHEA System S.A.
-//
-//    Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
-//
-//    This file is part of CDP4 Batch Editor. 
-//    The CDP4 Batch Editor is a commandline application to perform batch operations on a 
-//    ECSS-E-TM-10-25 Annex A and Annex C data source
-//
-//    The CDP4 Batch Editor is free software; you can redistribute it and/or
-//    modify it under the terms of the GNU Lesser General Public
-//    License as published by the Free Software Foundation; either
-//    version 3 of the License, or any later version.
-//
-//    The CDP4 Batch Editor is distributed in the hope that it will be useful,
-//    but WITHOUT ANY WARRANTY; without even the implied warranty of
-//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-//    GNU Affero General License for more details.
-//
-//    You should have received a copy of the GNU Affero General License
-//    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// </copyright>
-// --------------------------------------------------------------------------------------------------------------------
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="SessionServiceTestFixture.cs" company="RHEA System S.A.">
+//     Copyright (c) 2015-2020 RHEA System S.A.
+// 
+//     Author: Nathanael Smiechowski, Alex Vorobiev, Alexander van Delft, Kamil Wojnowski, Sam Gerené
+// 
+//     This file is part of CDP4 Batch Editor.
+//     The CDP4 Batch Editor is a commandline application to perform batch operations on a
+//     ECSS-E-TM-10-25 Annex A and Annex C data source
+// 
+//     The CDP4 Batch Editor is free software; you can redistribute it and/or
+//     modify it under the terms of the GNU Lesser General Public
+//     License as published by the Free Software Foundation; either
+//     version 3 of the License, or any later version.
+// 
+//     The CDP4 Batch Editor is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//     GNU Lesser General License version 3 for more details.
+// 
+//     You should have received a copy of the GNU Lesser General License
+//     along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
 
 namespace CDPBatchEditor.Tests.Services
 {
@@ -45,20 +45,6 @@ namespace CDPBatchEditor.Tests.Services
     [TestFixture]
     public class SessionServiceTestFixture
     {
-        private const string BaseUri = "http://test.com";
-        private Mock<ISession> session;
-        private Uri uri;
-        private SiteDirectory siteDirectory;
-        private Iteration iteration;
-        private DomainOfExpertise domain;
-        private Person person;
-        private Participant participant;
-        private Assembler assembler;
-        private SessionService sessionService;
-        private Mock<IFilterService> filterService;
-        private Mock<ICommandArguments> commandArguments;
-        private EngineeringModel engineeringModel;
-
         [SetUp]
         public void Setup()
         {
@@ -108,16 +94,36 @@ namespace CDPBatchEditor.Tests.Services
             this.sessionService = new SessionService(this.commandArguments.Object, this.filterService.Object, this.session.Object);
         }
 
-        [Test]
-        public void VerifySessionOpen()
+        private const string BaseUri = "http://test.com";
+        private Mock<ISession> session;
+        private Uri uri;
+        private SiteDirectory siteDirectory;
+        private Iteration iteration;
+        private DomainOfExpertise domain;
+        private Person person;
+        private Participant participant;
+        private Assembler assembler;
+        private SessionService sessionService;
+        private Mock<IFilterService> filterService;
+        private Mock<ICommandArguments> commandArguments;
+        private EngineeringModel engineeringModel;
+
+        private ThingTransaction CreateDummyTransactions()
         {
-            Assert.IsTrue(this.sessionService.IsSessionOpen());
+            var elementDefinition = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri);
+
+            this.iteration.Element.Add(elementDefinition);
+
+            var transactionContext = TransactionContextResolver.ResolveContext(this.iteration);
+            return new ThingTransaction(transactionContext, elementDefinition);
         }
 
         [Test]
-        public void VerifySetProperties()
+        public void VerifyOpen()
         {
-            Assert.IsTrue(this.sessionService.SetProperties());
+            this.session.Setup(x => x.Open());
+            this.sessionService.Open();
+            this.session.Verify(x => x.Open(), Times.Once);
         }
 
         [Test]
@@ -140,21 +146,15 @@ namespace CDPBatchEditor.Tests.Services
         }
 
         [Test]
-        public void VerifyOpen()
+        public void VerifySessionOpen()
         {
-            this.session.Setup(x => x.Open());
-            this.sessionService.Open();
-            this.session.Verify(x => x.Open(), Times.Once);
+            Assert.IsTrue(this.sessionService.IsSessionOpen());
         }
 
-        private ThingTransaction CreateDummyTransactions()
+        [Test]
+        public void VerifySetProperties()
         {
-            var elementDefinition = new ElementDefinition(Guid.NewGuid(), this.assembler.Cache, this.uri);
-
-            this.iteration.Element.Add(elementDefinition);
-
-            var transactionContext = TransactionContextResolver.ResolveContext(this.iteration);
-            return new ThingTransaction(transactionContext, elementDefinition);
+            Assert.IsTrue(this.sessionService.SetProperties());
         }
     }
 }


### PR DESCRIPTION
For some reason test project ignored the previous cleanup. Licenses set to LGPL correctly now.