### PR TITLE
use java11 for sonar scanner

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,9 @@ before_build:
   - cmd: nuget restore
   - cmd: nuget install NUnit.Console -Version 3.11.1 -OutputDirectory testrunner
   - cmd: nuget install NUnit.Runners -Version 3.11.1 -OutputDirectory testrunner
+  - cmd: set "JAVA_HOME=C:\Program Files\Java\jdk11"
+  - cmd: set "PATH=C:\Program Files\Java\jdk11\bin;%PATH%"
+  - cmd: java -version
   - ps: >-
       if ($env:APPVEYOR_PULL_REQUEST_NUMBER) {
          Write-Host Sonar Scanning PR# $env:APPVEYOR_PULL_REQUEST_NUMBER


### PR DESCRIPTION
### Prerequisites

- [ ] I have written a descriptive pull-request title
- [ ] I have verified that there are no overlapping [pull-requests](https://github.com/RHEAGROUP/CDP4-BatchEditor-Community-Edition/pulls) open
- [ ] I have verified that I am following the CDP4-SDK [code style guidelines](https://raw.githubusercontent.com/RHEAGROUP/CDP4-BatchEditor-Community-Edition/master/.github/CONTRIBUTING.md)
- [ ] I have provided test coverage for my change (where applicable)

### Description
according to https://sonarcloud.io/documentation/user-guide/move-analysis-java-11/ we need to force sonarqube to use java11